### PR TITLE
Changed statement to determine http/https

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -23,7 +23,7 @@ const createServer = (httpPort: number, httpsPort: number) => {
   app.use("/timetables", timetablesRoute);
   app.use("/health", healthRoute);
 
-  if (process.env.ENABLE_HTTPS === "true") {
+  if (process.env.ENABLE_HTTPS === "false") {
     httpServer = http
       .createServer(app)
       .listen(80, () =>


### PR DESCRIPTION
Hi there,
from my understanding and trying out your project, the code is broken when you try to run the service without https.

I changed the statement to run the server on port 80 if the ENABLE_HTTPS is set to false in the .env

The variable should probably also be set in the .env.example file.