### PR TITLE
Prevent windows from using crlf

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
Prettier fails on operating systems that use CRLF end lines. Since this project is made on Linux (and thus uses LF end lines), force the type to be LF.