### PR TITLE
Fix: Only merge lessons when both lsnumber and date match

### DIFF
--- a/src/lessons/lessons.service.ts
+++ b/src/lessons/lessons.service.ts
@@ -32,9 +32,20 @@ export class LessonsService {
   ) {
     const { error, value } = createEvents(
       lessons
+        .sort((a, b) =>
+          a.date !== b.date
+            ? a.date - b.date
+            : a.startTime !== b.startTime
+              ? a.startTime - b.startTime
+              : a.lsnumber - b.lsnumber,
+        )
         .reduce((acc, curr) => {
           const last = acc[acc.length - 1];
-          if (last && last.lsnumber === curr.lsnumber) {
+          if (
+            last &&
+            last.lsnumber === curr.lsnumber &&
+            last.date === curr.date // Only merge on same date
+          ) {
             last.endTime = curr.endTime;
             return acc;
           }

--- a/src/lessons/lessons.service.ts
+++ b/src/lessons/lessons.service.ts
@@ -44,7 +44,7 @@ export class LessonsService {
           if (
             last &&
             last.lsnumber === curr.lsnumber &&
-            last.date === curr.date // Only merge on same date
+            last.date === curr.date
           ) {
             last.endTime = curr.endTime;
             return acc;


### PR DESCRIPTION
### Problem
My school's export uses the same `lsnumber` for all lessons, regardless of subject or day. This caused the previous merging logic (which relied only on `lsnumber`) to overwrite events—e.g., only Math on Friday appeared, while Math on Monday was missing.

### Solution
Lessons are now only merged if both `lsnumber` and `date` match. This prevents unrelated lessons from being merged and ensures all events are exported correctly.

### Notes
- This change works for my export, but other schools might use different formats.
- Feedback and testing with other exports are welcome!

---

#### Request for Reviewers

This is my first pull request ever. Please let me know if you notice any issues or side effects with your data.

Thank you!